### PR TITLE
Refactor: axiosClient를 더 간편하게 사용하도록 수정

### DIFF
--- a/src/services/apis/miganziService.ts
+++ b/src/services/apis/miganziService.ts
@@ -34,7 +34,7 @@ export const postBoard = async (data: {}) => {
       processData: false,
     };
 
-    const response = await axiosClient.post(url, data, { headers });
+    const response = await axiosClient.axios(url, { headers, data });
     return response;
   } catch (error) {
     throw new Error(`POST Board Error: ${error}`);
@@ -49,7 +49,10 @@ export const postLogin = async (formData: any) => {
   try {
     const url = "user/login";
     const currentDate = Date.now().toString();
-    const response = await axiosClient.post(url, {}, formData);
+    const response = await axiosClient.axios(url, {
+      method: "post",
+      data: formData,
+    });
     //@ts-ignore
     localTokenRepoInstance.setRefresh(response.data?.data?.refreshToken);
     //@ts-ignore


### PR DESCRIPTION
### before
```typescript
    const response = await axiosClient.post(url, {}, formData);
```

### after
```typescript
const response = await axiosClient.axios(url, {
      method: "post",
      data: formData,
    });
```
- 사용하는 곳에서 직관적으로 표현하기 위해서 따로 만들었지만 method 키값을 활용해도 충분할 것 같습니다.

```typescript
async get<T>(
    url: string,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "GET" });
  }

  async post<T>(
    url: string,
    headers?: any,
    data?: any,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, {
      ...options,
      headers,
      method: "POST",
      data,
    });
  }

  async put<T>(
    url: string,
    data?: any,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "PUT", data });
  }

  async delete<T>(
    url: string,
    options: AxiosRequestConfig = {}
  ): Promise<AxiosResponse<T>> {
    return this.axios<T>(url, { ...options, method: "DELETE" });
  }
}
```

